### PR TITLE
Fix hexdoc-hexcasting dependency version to allow newer Hex versions in hexdoc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ key = "modVersion"
 
 [tool.hatch.metadata.hooks.gradle-properties]
 dependencies = [
-    { package="hexdoc-hexcasting", op="~=", py-version="1.0.dev20", key="hexcastingVersion" },
+    { package="hexdoc-hexcasting", op="~=", py-version="1.0", key="hexcastingVersion" },
 ]
 
 [tool.hatch.metadata.hooks.gradle-properties.optional-dependencies]


### PR DESCRIPTION
This resolves the following error in HexBug:

<img width="894" height="161" alt="image" src="https://github.com/user-attachments/assets/7a8630de-9f11-4c7d-ac05-1ddc582b00b7" />
