### PR TITLE
Fixed expressions of form `1 / x` and `2 * 2` not simplifying

### DIFF
--- a/common/src/main/java/dev/kineticcat/complexhex/api/util/Exprs.kt
+++ b/common/src/main/java/dev/kineticcat/complexhex/api/util/Exprs.kt
@@ -8,7 +8,7 @@ import java.text.DecimalFormat
 import kotlin.math.*
 
 abstract class UnaryOp(open val A: Expr): Expr() {
-    override fun equals(other: Any?): Boolean = other is UnaryOp && this.A == other.A
+    override fun equals(other: Any?): Boolean = other is UnaryOp && this::class == other::class && this.A == other.A
     override fun args(): List<Expr> = listOf(A)
     override fun contains(that: Expr) = super.contains(that) || A.contains(that)
 
@@ -22,7 +22,7 @@ abstract class UnaryOp(open val A: Expr): Expr() {
     }
 }
 abstract class BinaryOp(open val A: Expr, open val B: Expr): Expr() {
-    override fun equals(other: Any?): Boolean = other is BinaryOp && this.A == other.A && this.B == other.B
+    override fun equals(other: Any?): Boolean = other is BinaryOp && this::class == other::class && this.A == other.A && this.B == other.B
     override fun args(): List<Expr> = listOf(A, B)
 
     override fun contains(that: Expr) = super.contains(that) || A.contains(that) || B.contains(that)
@@ -163,7 +163,6 @@ class Div(override val A: Expr, override val B: Expr): BinaryOp(A, B) {
     override fun simplify(): Expr = when {
         A == Value.ZERO -> Value.ZERO
         B == Value.ZERO -> Infinity()
-        A == Value.ONE -> A / B
         B == Value.ONE -> A
         A is Mul && A.A == B -> A.B
         A is Mul && A.B == B -> A.A


### PR DESCRIPTION
Made equality checks for `UnaryOp` and `BinaryOp` more restrictive by also ensuring the classes of both are the same
Removed a `when` arm which tried to return `A / B` if `A == Value.ONE`

Fixes #33

### Rationale

The expression `2 * 2` would attempt to simplify into `2 ^ 2` (`^` representing exponentiation) but the loop in `Expr.simp` would check for equality between these two expressions and determine they are equal, thus incorrectly determining the simplification is complete as nothing has changed. This happens because both `Mul` and `Pow` inherit from `BinaryOp` and use its equality function, which only checks that both sides of the equality are of type `BinaryOp` and the `A` fields match each other and the `B` fields match each other. This causes simplification to halt incorrectly. To fix this, the equality function was modified to also check that the classes of `A` and `B` match. `UnaryOp` technically suffered from the same issue, though I don't believe there's any way to trigger it in the current version. I implemented the same fix there just in case.

I was completely unable to justify the inclusion of the `when` arm. At that point in execution, Kotlin knows `A` is a `Value` and `B` is an `Expr`, and so the only possible division overload to use is that of `Expr`'s division with another `Expr`, which returns the same `Div` we started with. Perhaps I'm missing something, but the inclusion of the  `when` arm only creates a bug where `Div` types with a numerator of `1` simplifies to itself every time (unless the denominator is `0`). I removed the arm.