### PR TITLE
Fix matrix conversion

### DIFF
--- a/common/src/main/java/dev/kineticcat/complexhex/api/Funnies.kt
+++ b/common/src/main/java/dev/kineticcat/complexhex/api/Funnies.kt
@@ -94,8 +94,8 @@ fun Matrix4f.toDoubleMatrix() = DoubleMatrix(4, 4,
 )
 
 fun DoubleMatrix.toMatrix4f() = Matrix4f(
-    this.get(0, 0).toFloat(), this.get(0, 1).toFloat(),this.get(0, 2).toFloat(),this.get(0, 3).toFloat(),
-    this.get(1, 0).toFloat(), this.get(1, 1).toFloat(),this.get(1, 2).toFloat(),this.get(1, 3).toFloat(),
-    this.get(2, 0).toFloat(), this.get(2, 1).toFloat(),this.get(2, 2).toFloat(),this.get(2, 3).toFloat(),
-    this.get(3, 0).toFloat(), this.get(3, 1).toFloat(),this.get(3, 2).toFloat(),this.get(3, 3).toFloat(),
+    this.get(0, 0).toFloat(), this.get(1, 0).toFloat(),this.get(2, 0).toFloat(),this.get(3, 0).toFloat(),
+    this.get(0, 1).toFloat(), this.get(1, 1).toFloat(),this.get(2, 1).toFloat(),this.get(3, 1).toFloat(),
+    this.get(0, 2).toFloat(), this.get(1, 2).toFloat(),this.get(2, 2).toFloat(),this.get(3, 2).toFloat(),
+    this.get(0, 3).toFloat(), this.get(1, 3).toFloat(),this.get(2, 3).toFloat(),this.get(3, 3).toFloat(),
 )

--- a/common/src/main/java/dev/kineticcat/complexhex/api/util/BITHandlers.kt
+++ b/common/src/main/java/dev/kineticcat/complexhex/api/util/BITHandlers.kt
@@ -205,7 +205,7 @@ object BITHandlers {
         }
         return Component.literal(iota.string)
     })
-    val TEXT_PATTERN = addTextDisplayHandler(StringIota::class.java, fun (iota, _, idx) : Component {
+    val TEXT_PATTERN = addTextDisplayHandler(PatternIota::class.java, fun (iota, _, idx) : Component {
         val pattern = (iota as PatternIota)
         return pattern.display()
     })

--- a/common/src/main/java/dev/kineticcat/complexhex/casting/actions/bits/OpSetBit4x4.kt
+++ b/common/src/main/java/dev/kineticcat/complexhex/casting/actions/bits/OpSetBit4x4.kt
@@ -25,7 +25,6 @@ object OpSetBit4x4 : SpellAction {
         var mat = args.getMatrix(1)
         env.assertEntityInRange(e)
         if (e !is Display) throw MishapBadEntity.of(e, "bit")
-        if (!(mat.rows == 4 && mat.columns == 4))
 
         mat = when (mat.rows to mat.columns) {
             3 to 3 -> DoubleMatrix.eye(4).put(IntervalRange(0,3), IntervalRange(0,3), mat)


### PR DESCRIPTION
fixes https://github.com/kineticneticat/ComplexHex/issues/45

Stops matrix from being transposed when going from jblas DoubleMatrix to joml Matrix4f
confusion stems from jblas using matrix.get(row, column) while joml using matrix.m\<column\>\<row\>